### PR TITLE
Support/compatibility updates

### DIFF
--- a/_template/README.md
+++ b/_template/README.md
@@ -22,7 +22,7 @@ See `attributes/default.rb`
 Add the `benchmark-name` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'benchmark-name@0.1.0'  # Version is optional
   chef.json =
   {

--- a/_template/README.md
+++ b/_template/README.md
@@ -22,7 +22,7 @@ See `attributes/default.rb`
 Add the `benchmark-name` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client' do |chef|
+config.vm.provision 'cwb', type: 'chef_client' do |chef|
   chef.add_recipe 'benchmark-name@0.1.0'  # Version is optional
   chef.json =
   {

--- a/_template/vagrant-aws/Vagrantfile
+++ b/_template/vagrant-aws/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'benchmark-name@0.1.0'  # Version is optional
     chef.json =
     {

--- a/_template/vagrant-aws/Vagrantfile
+++ b/_template/vagrant-aws/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client' do |chef|
+  config.vm.provision 'cwb', type: 'chef_client' do |chef|
     chef.add_recipe 'benchmark-name@0.1.0'  # Version is optional
     chef.json =
     {

--- a/cwb/test/cookbooks/cwb-test/README.md
+++ b/cwb/test/cookbooks/cwb-test/README.md
@@ -24,7 +24,7 @@ See `attributes/default.rb`
 Add the `cwb-test` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'cwb-test@0.1.0'  # Version is optional
   chef.json =
   {

--- a/cwb/test/cookbooks/cwb-test/vagrant-aws/Vagrantfile
+++ b/cwb/test/cookbooks/cwb-test/vagrant-aws/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # aws.security_groups = %w(default my_own_group)
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'cwb-test@0.1.0'  # Version is optional
     chef.json =
     {

--- a/iperf/README.md
+++ b/iperf/README.md
@@ -28,7 +28,7 @@ See `attributes/default.rb`
 Add the `iperf` client recipe to your Chef configuration:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'iperf::client@1.0.0'  # Version is optional
   chef.json =
   {

--- a/iperf/vagrant-aws/Vagrantfile
+++ b/iperf/vagrant-aws/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       aws.tags = { 'Name' => server_node_name }
     end
 
-    server.vm.provision 'chef_client', id: 'chef_client' do |chef|
+    server.vm.provision 'chef_client' do |chef|
       chef.node_name = server_node_name
       chef.add_recipe 'cli-benchmark'
       chef.json = {
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       aws.tags = { 'Name' => client_node_name }
     end
 
-    client.vm.provision 'chef_client', id: 'chef_client' do |chef|
+    client.vm.provision 'chef_client' do |chef|
       chef.node_name = client_node_name
       chef.add_recipe 'iperf::client'
       chef.json =

--- a/minimal-example/README.md
+++ b/minimal-example/README.md
@@ -21,7 +21,7 @@ See `attributes/default.rb`
 Add the `minimal-example` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'minimal-example@0.1.0'  # Version is optional
   chef.json =
   {

--- a/minimal-example/vagrant-aws/Vagrantfile
+++ b/minimal-example/vagrant-aws/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'minimal-example@0.1.0'  # Version is optional
     chef.json =
     {

--- a/molecular-dynamics-simulation/README.md
+++ b/molecular-dynamics-simulation/README.md
@@ -22,7 +22,7 @@ See `attributes/default.rb`
 Add the `molecular-dynamics-simulation` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'molecular-dynamics-simulation@0.1.0'  # Version is optional
   chef.json =
   {

--- a/molecular-dynamics-simulation/vagrant-aws/Vagrantfile
+++ b/molecular-dynamics-simulation/vagrant-aws/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'molecular-dynamics-simulation@0.1.0'  # Version is optional
     chef.json =
     {

--- a/phoronix-test-suite/README.md
+++ b/phoronix-test-suite/README.md
@@ -17,7 +17,7 @@ Metrics depends on what tests and metric names you define.
 Add the `phoronix-test-suite` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'phoronix-test-suite'
   chef.json =
   {

--- a/phoronix-test-suite/vagrant-aws/Vagrantfile
+++ b/phoronix-test-suite/vagrant-aws/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'phoronix-test-suite'
     chef.json =
     {

--- a/sysbench-monitored/README.md
+++ b/sysbench-monitored/README.md
@@ -34,7 +34,7 @@ See `attributes/default.rb` for monitoring related attributes
 Add the `sysbench-monitored` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'sysbench-monitored'
   chef.json =
   {

--- a/sysbench-monitored/vagrant-aws/Vagrantfile
+++ b/sysbench-monitored/vagrant-aws/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'sysbench-monitored@1.0.0'
     chef.json =
     {

--- a/sysbench/README.md
+++ b/sysbench/README.md
@@ -32,7 +32,7 @@ See `attributes/default.rb`
 Add the `sysbench` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'sysbench@1.0.1'
   chef.json =
   {

--- a/sysbench/vagrant-aws/Vagrantfile
+++ b/sysbench/vagrant-aws/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.instance_type = 't1.micro'
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'sysbench@1.0.1'
     chef.json =
         {

--- a/wordpress-bench/README.md
+++ b/wordpress-bench/README.md
@@ -33,7 +33,7 @@ See `attributes/default.rb`
 Add the `wordpress-bench` default recipe to your Chef configuration in the Vagrantfile:
 
 ```ruby
-config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+config.vm.provision 'chef_client' do |chef|
   chef.add_recipe 'wordpress-bench@0.1.0'  # Version is optional
   chef.json =
   {

--- a/wordpress-bench/vagrant-aws/Vagrantfile
+++ b/wordpress-bench/vagrant-aws/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # aws.security_groups = %w(default my_own_group)
   end
 
-  config.vm.provision 'chef_client', id: 'chef_client' do |chef|
+  config.vm.provision 'chef_client' do |chef|
     chef.add_recipe 'wordpress-bench@0.1.0'  # Version is optional
     chef.json =
     {

--- a/www-app-compile/vagrant-aws-large/Vagrantfile
+++ b/www-app-compile/vagrant-aws-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-app-compile/vagrant-aws-large/Vagrantfile
+++ b/www-app-compile/vagrant-aws-large/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"

--- a/www-app-compile/vagrant-aws-micro/Vagrantfile
+++ b/www-app-compile/vagrant-aws-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-app-compile/vagrant-aws-micro/Vagrantfile
+++ b/www-app-compile/vagrant-aws-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-app-compile/vagrant-aws-small/Vagrantfile
+++ b/www-app-compile/vagrant-aws-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-app-compile/vagrant-aws-small/Vagrantfile
+++ b/www-app-compile/vagrant-aws-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-app-mysql-longterm/vagrant-aws-eu-small/Vagrantfile
+++ b/www-app-mysql-longterm/vagrant-aws-eu-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-app-mysql-longterm/vagrant-aws-eu-small/Vagrantfile
+++ b/www-app-mysql-longterm/vagrant-aws-eu-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-app-mysql/vagrant-aws-eu-large/Vagrantfile
+++ b/www-app-mysql/vagrant-aws-eu-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-app-mysql/vagrant-aws-eu-large/Vagrantfile
+++ b/www-app-mysql/vagrant-aws-eu-large/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"

--- a/www-app-mysql/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-app-mysql/vagrant-aws-eu-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-app-mysql/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-app-mysql/vagrant-aws-eu-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-app-mysql/vagrant-aws-eu-small/Vagrantfile
+++ b/www-app-mysql/vagrant-aws-eu-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-app-mysql/vagrant-aws-eu-small/Vagrantfile
+++ b/www-app-mysql/vagrant-aws-eu-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-micro-benchmarks/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-benchmarks/vagrant-aws-eu-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-benchmarks/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-benchmarks/vagrant-aws-eu-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-benchmarks/vagrant-aws-eu-small/Vagrantfile
+++ b/www-micro-benchmarks/vagrant-aws-eu-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-benchmarks/vagrant-aws-eu-small/Vagrantfile
+++ b/www-micro-benchmarks/vagrant-aws-eu-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-cpu-longterm/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-cpu-longterm/vagrant-aws-eu-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-cpu-longterm/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-cpu-longterm/vagrant-aws-eu-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-eu-large/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-eu-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-eu-large/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-eu-large/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"

--- a/www-micro-cpu/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-eu-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-cpu/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-eu-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-eu-small/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-eu-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-micro-cpu/vagrant-aws-eu-small/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-eu-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-use-large/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-use-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-018c9568"
       region.keypair_name = "rubis"
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-use-micro/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-use-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "us-east-1"
     aws.region_config "us-east-1" do |region|
       region.ami = "ami-018c9568"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-cpu/vagrant-aws-use-micro/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-use-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-018c9568"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-use-small/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-use-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-018c9568"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-micro-cpu/vagrant-aws-use-small/Vagrantfile
+++ b/www-micro-cpu/vagrant-aws-use-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "us-east-1"
     aws.region_config "us-east-1" do |region|
       region.ami = "ami-018c9568"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-micro-io-longterm/vagrant-aws-large/Vagrantfile
+++ b/www-micro-io-longterm/vagrant-aws-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-micro-io-longterm/vagrant-aws-large/Vagrantfile
+++ b/www-micro-io-longterm/vagrant-aws-large/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"

--- a/www-micro-io-longterm/vagrant-aws-micro/Vagrantfile
+++ b/www-micro-io-longterm/vagrant-aws-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-io-longterm/vagrant-aws-micro/Vagrantfile
+++ b/www-micro-io-longterm/vagrant-aws-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-io-longterm/vagrant-aws-small/Vagrantfile
+++ b/www-micro-io-longterm/vagrant-aws-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-micro-io-longterm/vagrant-aws-small/Vagrantfile
+++ b/www-micro-io-longterm/vagrant-aws-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-micro-io/vagrant-aws-large/Vagrantfile
+++ b/www-micro-io/vagrant-aws-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-micro-io/vagrant-aws-large/Vagrantfile
+++ b/www-micro-io/vagrant-aws-large/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"

--- a/www-micro-io/vagrant-aws-micro/Vagrantfile
+++ b/www-micro-io/vagrant-aws-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-io/vagrant-aws-micro/Vagrantfile
+++ b/www-micro-io/vagrant-aws-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-io/vagrant-aws-small-instancestore/Vagrantfile
+++ b/www-micro-io/vagrant-aws-small-instancestore/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-116b9166"     # this is Ubuntu Trusty 14.04 with Instance-Store instead of EBS
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-micro-io/vagrant-aws-small-instancestore/Vagrantfile
+++ b/www-micro-io/vagrant-aws-small-instancestore/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-116b9166"     # this is Ubuntu Trusty 14.04 with Instance-Store instead of EBS
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-micro-io/vagrant-aws-small/Vagrantfile
+++ b/www-micro-io/vagrant-aws-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-micro-io/vagrant-aws-small/Vagrantfile
+++ b/www-micro-io/vagrant-aws-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]

--- a/www-micro-mem/vagrant-aws-eu-large/Vagrantfile
+++ b/www-micro-mem/vagrant-aws-eu-large/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"
     aws.security_groups = ["default"]

--- a/www-micro-mem/vagrant-aws-eu-large/Vagrantfile
+++ b/www-micro-mem/vagrant-aws-eu-large/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m3.large"

--- a/www-micro-mem/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-mem/vagrant-aws-eu-micro/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"

--- a/www-micro-mem/vagrant-aws-eu-micro/Vagrantfile
+++ b/www-micro-mem/vagrant-aws-eu-micro/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "t1.micro"
     aws.security_groups = ["default"]

--- a/www-micro-mem/vagrant-aws-eu-small/Vagrantfile
+++ b/www-micro-mem/vagrant-aws-eu-small/Vagrantfile
@@ -23,7 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = "eu-west-1"
     aws.region_config "eu-west-1" do |region|
       region.ami = "ami-896c96fe"
-      region.keypair_name = ENV['EC2_KEYPAIR']
     end
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"

--- a/www-micro-mem/vagrant-aws-eu-small/Vagrantfile
+++ b/www-micro-mem/vagrant-aws-eu-small/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       region.ami = "ami-896c96fe"
       region.keypair_name = ENV['EC2_KEYPAIR']
     end
-    override.ssh.private_key_path = ENV['EC2_PRIVATE_KEY']
     override.ssh.username = "ubuntu"
     aws.instance_type = "m1.small"
     aws.security_groups = ["default"]


### PR DESCRIPTION
The id attribute for provisioners (`id: 'chef_client'`) has been removed in Vagrant 1.8
### OLD

``` ruby
config.vm.provision 'chef_client', id: 'chef_client' do |chef|
```
### NEW

``` ruby
config.vm.provision 'cwb', type: 'chef_client' do |chef|
```
