### PR TITLE
Add JMeter PerfMon-based performance monitoring cookbook

### DIFF
--- a/perfmon/.kitchen.yml
+++ b/perfmon/.kitchen.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: vagrant
+  customize:
+    memory: 1024
+    cpus: 2
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: 12.8.1
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[perfmon::default]
+    attributes:

--- a/perfmon/Berksfile
+++ b/perfmon/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+metadata

--- a/perfmon/Berksfile.lock
+++ b/perfmon/Berksfile.lock
@@ -1,0 +1,30 @@
+DEPENDENCIES
+  perfmon
+    path: .
+    metadata: true
+
+GRAPH
+  apt (5.0.1)
+    compat_resource (>= 12.16.3)
+  ark (2.2.1)
+    build-essential (>= 0.0.0)
+    seven_zip (>= 0.0.0)
+    windows (>= 0.0.0)
+  build-essential (8.0.0)
+    mingw (>= 1.1)
+    seven_zip (>= 0.0.0)
+  compat_resource (12.16.3)
+  mingw (2.0.0)
+    seven_zip (>= 0.0.0)
+  ohai (5.0.0)
+  perfmon (0.1.0)
+    apt (~> 5.0.1)
+    ark (~> 2.2.1)
+    poise-service (~> 1.4.2)
+  poise (2.7.2)
+  poise-service (1.4.2)
+    poise (~> 2.0)
+  seven_zip (2.0.2)
+    windows (>= 1.2.2)
+  windows (2.1.1)
+    ohai (>= 4.0.0)

--- a/perfmon/CHANGELOG.md
+++ b/perfmon/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (2017-03-12)
+
+Initial release of `perfmon`

--- a/perfmon/LICENSE
+++ b/perfmon/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/perfmon/README.md
+++ b/perfmon/README.md
@@ -1,0 +1,54 @@
+# perfmon
+
+Installs the PerfMon server agent as a service to be used in combination with JMeter.
+See https://jmeter-plugins.org/wiki/PerfMonAgent/
+
+## Attributes
+
+See `attributes/default.rb`
+
+## Usage
+
+### perfmon::default
+
+Add the `perfmon` default recipe to your Chef configuration in the Vagrantfile:
+
+```ruby
+config.vm.provision 'cwb', type: 'chef_client' do |chef|
+  chef.add_recipe 'perfmon'
+  chef.json =
+  {
+    'perfmon' => {
+        # 0 = disabled
+        'udp-port' => 0,
+        'tcp-port' => 4444,
+    },
+  }
+end
+```
+
+## Administration
+
+* Installation directory: `/usr/local/perfmon`
+
+* Start service:
+
+    ```shell
+    sudo service perfmon start
+    ```
+
+* Stop service:
+
+    ```shell
+    sudo service perfmon stop
+    ```
+
+* Check logs:
+
+    ```shell
+    tail -f /var/log/upstart/perfmon.log
+    ```
+
+## License and Authors
+
+Author:: Joel Scheuner (joel.scheuner.dev@gmail.com)

--- a/perfmon/attributes/default.rb
+++ b/perfmon/attributes/default.rb
@@ -1,0 +1,10 @@
+## Installation
+default['perfmon']['version'] = '2.2.1'
+default['perfmon']['source_url'] = "https://jmeter-plugins.org/downloads/file/ServerAgent-#{node['perfmon']['version']}.zip"
+# SHA-256 checksum: `shasum -a 256`
+default['perfmon']['checksum'] = '2d5cfd6d579acfb89bf16b0cbce01c8817cba52ab99b3fca937776a72a8f95ec'
+
+## Runtime
+default['perfmon']['service'] = 'enable' # or 'disable' according to https://github.com/poise/poise-service#actions
+default['perfmon']['user'] = (node['benchmark']['ssh_username'] rescue 'root')
+default['perfmon']['cli_args'] = '--udp-port 0 --tcp-port 4444'

--- a/perfmon/chefignore
+++ b/perfmon/chefignore
@@ -1,0 +1,94 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/perfmon/metadata.rb
+++ b/perfmon/metadata.rb
@@ -1,0 +1,12 @@
+# Docs: https://docs.chef.io/config_rb_metadata.html
+name             'perfmon'
+maintainer       'Joel Scheuner'
+maintainer_email 'joel.scheuner.dev@gmail.com'
+license          'MIT'
+description      'Installs the PerfMon server agent as a service'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+depends 'apt', '~> 5.0.1'
+depends 'ark', '~> 2.2.1'
+depends 'poise-service', '~> 1.4.2'

--- a/perfmon/recipes/default.rb
+++ b/perfmon/recipes/default.rb
@@ -1,0 +1,2 @@
+include_recipe 'perfmon::install'
+include_recipe 'perfmon::service'

--- a/perfmon/recipes/install.rb
+++ b/perfmon/recipes/install.rb
@@ -1,0 +1,14 @@
+include_recipe 'apt::default'
+package 'default-jre' do
+  action :install
+end
+package 'unzip'
+
+ark 'perfmon' do
+  url node['perfmon']['source_url']
+  version node['perfmon']['version']
+  checksum node['perfmon']['checksum']
+  # See: https://github.com/chef-cookbooks/ark/issues/72#issuecomment-146268255
+  strip_components 0
+  action :install
+end

--- a/perfmon/recipes/service.rb
+++ b/perfmon/recipes/service.rb
@@ -1,0 +1,7 @@
+poise_service 'perfmon' do
+  command "./startAgent.sh #{node['perfmon']['cli_args']}"
+  user node['perfmon']['user']
+  directory '/usr/local/perfmon'
+  # environment JAVA_HOME: ...
+  action node['perfmon']['service'].to_sym
+end


### PR DESCRIPTION
This cookbook installs and starts the PerfMon agent as `perfmon` service.