### PR TITLE
Fix RMIT randomization scope

### DIFF
--- a/rmit-combined/files/default/rmit_benchmark_suite.rb
+++ b/rmit-combined/files/default/rmit_benchmark_suite.rb
@@ -70,12 +70,8 @@ module Cwb
       # described in the paper: Conducting Repeatable Experiments in Highly Variable Cloud Computing Environments
       # A. Abedi and T. Brecht (2017)
       def rmit_list(list)
-        repeated_list(list, repetitions).shuffle
-      end
-
-      def repeated_list(list, repetitions)
         repeated_list = []
-        repetitions.times { repeated_list.concat list }
+        repetitions.times { repeated_list.concat list.shuffle }
         repeated_list
       end
 


### PR DESCRIPTION
According to the RMIT definition presented in
"Conducting Repeatable Experiments in Highly Variable Cloud Computing Environments" \cite{Abedi:2017aa}
ordering randomization should be only applied to the individual blocks and not to the entire ordered list.