### PR TITLE
Fix erroneous reported number of CPU cores

### DIFF
--- a/rmit-combined/files/default/iperf_client.rb
+++ b/rmit-combined/files/default/iperf_client.rb
@@ -4,6 +4,7 @@ require 'socket'
 # Also see `iperf.rb`
 class IperfClient < Cwb::Benchmark
   DURATION = 30 # seconds
+  PORT = 5678
 
   def execute
     run('single-thread', cmd(1))
@@ -25,14 +26,10 @@ class IperfClient < Cwb::Benchmark
     "iperf -c #{host} -l 128k -t #{DURATION} -P #{num_threads}"
   end
 
-  def num_cpu_cores
-    @cwb.deep_fetch('cpu', '0', 'cores').to_i
-  end
-
   def notify_completion
-    server = TCPSocket.new(host, port)
+    server = TCPSocket.new(host, PORT)
     line = server.gets
-    raise "[iperf/load-generator] Could not notify completion to #{host}:#{port}" if line.strip != 'OK'
+    raise "[iperf/load-generator] Could not notify completion to #{host}:#{PORT}" if line.strip != 'OK'
     server.close
   end
 
@@ -40,12 +37,8 @@ class IperfClient < Cwb::Benchmark
     @cwb.deep_fetch('rmit-combined', 'public_host')
   end
 
-  def port
-    5678
-  end
-
-  def cpu_cores
-    @cwb.deep_fetch('cpu', '0', 'cores').to_i
+  def num_cpu_cores
+    @cwb.deep_fetch('cpu', 'cores').to_i
   end
 
   def timestamp

--- a/rmit-combined/files/default/rmit_benchmark_suite.rb
+++ b/rmit-combined/files/default/rmit_benchmark_suite.rb
@@ -31,7 +31,7 @@ module Cwb
 
     def submit_global_metrics
       @cwb.submit_metric('instance/cpu-model', timestamp, cpu_model_name)
-      @cwb.submit_metric('instance/cpu-cores', timestamp, cpu_cores)
+      @cwb.submit_metric('instance/cpu-cores', timestamp, num_cpu_cores)
       @cwb.submit_metric('instance/ram-total', timestamp, node_ram_in_kB)
       @cwb.submit_metric('instance/gcc-version', timestamp, `gcc --version | head -n 1`.strip)
       @cwb.submit_metric('sysbench/version', timestamp, `sysbench --version`.strip)
@@ -104,8 +104,8 @@ module Cwb
         @cwb.deep_fetch('cpu', '0', 'model_name')
       end
 
-      def cpu_cores
-        @cwb.deep_fetch('cpu', '0', 'cores')
+      def num_cpu_cores
+        @cwb.deep_fetch('cpu', 'cores')
       end
 
       def node_ram_in_kB

--- a/rmit-combined/files/default/sysbench_cpu.rb
+++ b/rmit-combined/files/default/sysbench_cpu.rb
@@ -24,7 +24,7 @@ class SysbenchCpu < Cwb::Benchmark
   end
 
   def num_cpu_cores
-    @cwb.deep_fetch('cpu', '0', 'cores').to_i
+    @cwb.deep_fetch('cpu', 'cores').to_i
   end
 
   def timestamp


### PR DESCRIPTION
Using the Ohai `cpu.cores` attribute now:
https://github.com/chef/ohai/blob/master/lib/ohai/plugins/linux/cpu.rb

Beforehand `cpu.0.cores` always reported 1